### PR TITLE
Check dependabot version updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     reviewers:
       - "semestry/developers-nl"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
## Proposed changes

semestry/template-openapi#6 resulted in using Dependabot version updates for repositories connected to OpenAPI specifications. Initially check frequency "daily" was chosen. That is changed to "monthly".
The number of PRs that can be created by Dependabot in one run is now limited to 15.  Based on our experience with the daily schedule that is enough, but we will have to monitor that. 

## Testing

Cannot be tested. The daily process works well, there is no reason to assume it will not work with a monthly schedule.

## Documentation

N/A